### PR TITLE
Post의 Table of Contents UI 세부 구현 변경

### DIFF
--- a/src/views/PostDetailView.vue
+++ b/src/views/PostDetailView.vue
@@ -18,11 +18,12 @@
         </div>
 
         <div
-            class="surface-600 text-300 text-lg p-3 mt-3 font-bold border-round flex flex-column align-items-start justify-content-center">
+            class="surface-600 text-300 text-lg p-3 mt-3 font-bold border-round flex flex-column align-items-start justify-content-center cursor-pointer"
+            @click="tocClick()">
             <div class="">
-                <i v-if="!tocOpen" class="pi pi-caret-right" @click="tocClick()"></i>
-                <i v-else class="pi pi-caret-down" @click="tocClick()"></i>
-                &nbsp; Table of Contents
+                <i v-if="!tocOpen" class="pi pi-caret-right"></i>
+                <i v-else class="pi pi-caret-down"></i>
+                <span class="ml-2">Table of Contents</span>
             </div>
             <div v-if="tocOpen" class="mt-2">
                 <div v-for="item in tocItems" :key="item.text" class="m-2 px-3">


### PR DESCRIPTION
div 전체를 클릭했을 때 작동하도록 변경했다.
(기존: 아이콘을 클릭했을 때 작동)

아이콘과 문구 "Table of Contents" 사이 간격을
CSS로 변경했다.
(기존: nbsp 문자 사용)